### PR TITLE
Rename NewNode function

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -28,7 +28,7 @@ func BenchmarkP2PNode_Publish(b *testing.B) {
 		Port:               3111,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(b, err)
 	defer node.Stop(ctx)
 
@@ -78,7 +78,7 @@ func BenchmarkP2PNode_SendToPeer(b *testing.B) {
 		Port:               3111,
 	}
 
-	sender, err := NewP2PNode(ctx, logger, config1)
+	sender, err := NewNode(ctx, logger, config1)
 	require.NoError(b, err)
 	defer sender.Stop(ctx)
 
@@ -89,7 +89,7 @@ func BenchmarkP2PNode_SendToPeer(b *testing.B) {
 		Port:               3112,
 	}
 
-	receiver, err := NewP2PNode(ctx, logger, config2)
+	receiver, err := NewNode(ctx, logger, config2)
 	require.NoError(b, err)
 	defer receiver.Stop(ctx)
 
@@ -155,7 +155,7 @@ func BenchmarkP2PNode_ConcurrentConnections(b *testing.B) {
 		Port:               3111,
 	}
 
-	central, err := NewP2PNode(ctx, logger, centralConfig)
+	central, err := NewNode(ctx, logger, centralConfig)
 	require.NoError(b, err)
 	defer central.Stop(ctx)
 
@@ -188,7 +188,7 @@ func BenchmarkP2PNode_ConcurrentConnections(b *testing.B) {
 						}
 
 						var node *Node
-						node, err = NewP2PNode(ctx, logger, config)
+						node, err = NewNode(ctx, logger, config)
 						if err != nil {
 							b.Error(err)
 							return
@@ -243,7 +243,7 @@ func BenchmarkP2PNode_MessageRouting(b *testing.B) {
 			}
 		}
 
-		node, err := NewP2PNode(ctx, logger, config)
+		node, err := NewNode(ctx, logger, config)
 		require.NoError(b, err)
 
 		err = node.Start(ctx, nil, "bench-routing")
@@ -333,7 +333,7 @@ func BenchmarkP2PNode_PeerManagement(b *testing.B) {
 		Port:               3111,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(b, err)
 	defer node.host.Close()
 
@@ -429,7 +429,7 @@ func BenchmarkP2PNode_MemoryAllocation(b *testing.B) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.ErrorLevel)
 
-	b.Run("NewP2PNode", func(b *testing.B) {
+	b.Run("NewNode", func(b *testing.B) {
 		ctx := context.Background()
 
 		b.ResetTimer()
@@ -441,7 +441,7 @@ func BenchmarkP2PNode_MemoryAllocation(b *testing.B) {
 				Port:               3111 + i,
 			}
 
-			node, err := NewP2PNode(ctx, logger, config)
+			node, err := NewNode(ctx, logger, config)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/examples/example.go
+++ b/examples/example.go
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	// Create P2P node
-	node, err := p2p.NewP2PNode(ctx, logger, config)
+	node, err := p2p.NewNode(ctx, logger, config)
 	if err != nil {
 		log.Fatalf("Failed to create P2P node: %v", err)
 	}

--- a/node.go
+++ b/node.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// NewP2PNode creates and initializes a new P2P network node with the provided configuration.
+// NewNode creates and initializes a new P2P network node with the provided configuration.
 // This constructor performs the core setup of the libp2p networking stack, including:
 //   - Setting up the node's cryptographic identity (private key)
 //   - Configuring network transports and listeners
@@ -45,7 +45,7 @@ import (
 //   - config: P2P-specific configuration parameters defining network behavior
 //
 // Returns a fully initialized P2P node ready for starting, or an error if initialization fails.
-func NewP2PNode(ctx context.Context, logger *logrus.Logger, config Config) (*Node, error) {
+func NewNode(ctx context.Context, logger *logrus.Logger, config Config) (*Node, error) {
 	logger.Infof("[Node] Creating node")
 
 	var (

--- a/node_messaging_test.go
+++ b/node_messaging_test.go
@@ -25,7 +25,7 @@ func TestP2PNode_TopicOperations(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.Stop(ctx)
 
@@ -90,7 +90,7 @@ func TestP2PNode_Publishing(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.Stop(ctx)
 
@@ -155,7 +155,7 @@ func TestP2PNode_Publishing(t *testing.T) {
 		Port:            0,
 	}
 
-	sender, err := NewP2PNode(ctx, logger, config1)
+	sender, err := NewNode(ctx, logger, config1)
 	require.NoError(t, err)
 	defer sender.Stop(ctx)
 
@@ -165,7 +165,7 @@ func TestP2PNode_Publishing(t *testing.T) {
 		Port:            0,
 	}
 
-	receiver, err := NewP2PNode(ctx, logger, config2)
+	receiver, err := NewNode(ctx, logger, config2)
 	require.NoError(t, err)
 	defer receiver.Stop(ctx)
 
@@ -233,7 +233,7 @@ func TestP2PNode_InitGossipSub(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -253,7 +253,7 @@ func TestP2PNode_InitGossipSub(t *testing.T) {
 
 	t.Run("initGossipSub empty topics", func(t *testing.T) {
 		// Reset node
-		node2, err := NewP2PNode(ctx, logger, config)
+		node2, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 		defer node2.host.Close()
 
@@ -275,7 +275,7 @@ func TestSubscribeToTopics(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -312,7 +312,7 @@ func TestP2PNode_ConcurrentPublishing(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.Stop(ctx)
 
@@ -367,7 +367,7 @@ func TestP2PNode_HandlerContextCancellation(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(context.Background(), logger, config)
+	node, err := NewNode(context.Background(), logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -428,7 +428,7 @@ func TestSubscribeToTopics_Error(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 

--- a/node_network_test.go
+++ b/node_network_test.go
@@ -32,7 +32,7 @@ func TestP2PNode_StaticPeerConnection(t *testing.T) {
 		Port:               3111, // Random port
 	}
 
-	node1, err := NewP2PNode(ctx, logger, config1)
+	node1, err := NewNode(ctx, logger, config1)
 	require.NoError(t, err)
 	defer node1.Stop(ctx)
 
@@ -48,7 +48,7 @@ func TestP2PNode_StaticPeerConnection(t *testing.T) {
 		StaticPeers:        []string{node1Addr},
 	}
 
-	node2, err := NewP2PNode(ctx, logger, config2)
+	node2, err := NewNode(ctx, logger, config2)
 	require.NoError(t, err)
 	defer node2.Stop(ctx)
 
@@ -90,7 +90,7 @@ func TestP2PNode_ShouldSkipPeer(t *testing.T) {
 		OptimiseRetries: false,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -156,7 +156,7 @@ func TestP2PNode_ShouldSkipBasedOnErrors(t *testing.T) {
 		OptimiseRetries: true,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -230,7 +230,7 @@ func TestP2PNode_ShouldSkipNoGoodAddresses(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -300,7 +300,7 @@ func TestP2PNode_AttemptConnection(t *testing.T) {
 		Port:               3111,
 	}
 
-	node1, err := NewP2PNode(ctx, logger, config1)
+	node1, err := NewNode(ctx, logger, config1)
 	require.NoError(t, err)
 	defer node1.host.Close()
 
@@ -311,7 +311,7 @@ func TestP2PNode_AttemptConnection(t *testing.T) {
 		Port:               3112,
 	}
 
-	node2, err := NewP2PNode(ctx, logger, config2)
+	node2, err := NewNode(ctx, logger, config2)
 	require.NoError(t, err)
 	defer node2.host.Close()
 
@@ -451,7 +451,7 @@ func TestP2PNode_InitDHT(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -484,7 +484,7 @@ func TestP2PNode_InitPrivateDHT(t *testing.T) {
 			DHTProtocolID:      "/test/dht/1.0.0",
 		}
 
-		node, err := NewP2PNode(ctx, logger, config)
+		node, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 		defer node.host.Close()
 
@@ -503,7 +503,7 @@ func TestP2PNode_InitPrivateDHT(t *testing.T) {
 			DHTProtocolID:      "/test/dht/1.0.0",
 		}
 
-		node, err := NewP2PNode(ctx, logger, config)
+		node, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 		defer node.host.Close()
 
@@ -522,7 +522,7 @@ func TestP2PNode_InitPrivateDHT(t *testing.T) {
 			DHTProtocolID:      "",
 		}
 
-		node, err := NewP2PNode(ctx, logger, config)
+		node, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 		defer node.host.Close()
 

--- a/node_test.go
+++ b/node_test.go
@@ -111,7 +111,7 @@ func TestNewP2PNode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			node, err := NewP2PNode(ctx, logger, tt.config)
+			node, err := NewNode(ctx, logger, tt.config)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -157,7 +157,7 @@ func TestP2PNode_StartStop(t *testing.T) {
 			Port:            0,
 		}
 
-		node, err := NewP2PNode(ctx, logger, config)
+		node, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 		require.NotNil(t, node)
 
@@ -185,7 +185,7 @@ func TestP2PNode_StartStop(t *testing.T) {
 			Port:            0,
 		}
 
-		node, err := NewP2PNode(ctx, logger, config)
+		node, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 
 		streamHandler := func(stream network.Stream) {
@@ -213,7 +213,7 @@ func TestP2PNode_StartStop(t *testing.T) {
 			Port:            0,
 		}
 
-		node, err := NewP2PNode(ctx, logger, config)
+		node, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 
 		topics := []string{"topic1", "topic2", "topic3"}
@@ -242,7 +242,7 @@ func TestP2PNode_BasicGetters(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -286,7 +286,7 @@ func TestP2PNode_Metrics(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -309,7 +309,7 @@ func TestP2PNode_PeerManagement(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -372,7 +372,7 @@ func TestP2PNode_Callbacks(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 
@@ -400,7 +400,7 @@ func TestP2PNode_Callbacks(t *testing.T) {
 
 	t.Run("callback not set", func(t *testing.T) {
 		// Create new node without callback
-		node2, err := NewP2PNode(ctx, logger, config)
+		node2, err := NewNode(ctx, logger, config)
 		require.NoError(t, err)
 		defer node2.host.Close()
 
@@ -423,7 +423,7 @@ func TestP2PNode_ThreadSafety(t *testing.T) {
 		Port:            0,
 	}
 
-	node, err := NewP2PNode(ctx, logger, config)
+	node, err := NewNode(ctx, logger, config)
 	require.NoError(t, err)
 	defer node.host.Close()
 


### PR DESCRIPTION
This pull request refactors the naming of the `NewP2PNode` constructor function to `NewNode` across the codebase for consistency and clarity. The changes affect the implementation, tests, and documentation of the P2P networking module.

### Constructor Renaming:

* [`node.go`](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4L35-R35): Renamed `NewP2PNode` to `NewNode` in the function definition and its associated comment, ensuring the documentation reflects the updated name. [[1]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4L35-R35) [[2]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4L48-R48)

### Benchmark Updates:

* [`benchmark_test.go`](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL31-R31): Updated all instances of `NewP2PNode` to `NewNode` in benchmark functions, such as `BenchmarkP2PNode_Publish`, `BenchmarkP2PNode_SendToPeer`, and others. This ensures the benchmarks use the new constructor name. [[1]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL31-R31) [[2]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL81-R81) [[3]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL92-R92) [[4]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL158-R158) [[5]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL191-R191) [[6]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL246-R246) [[7]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL336-R336) [[8]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL432-R432) [[9]](diffhunk://#diff-b045c16cb15dd06c03588480a6a3e04165b4fc09e646902e1f025099309c799dL444-R444)

### Test Updates:

* `node_messaging_test.go`, `node_network_test.go`, and `node_test.go`: Replaced `NewP2PNode` with `NewNode` in all test cases, including `TestP2PNode_TopicOperations`, `TestP2PNode_StaticPeerConnection`, `TestP2PNode_StartStop`, and others. This ensures tests align with the updated function name. [[1]](diffhunk://#diff-58730e6603ec58db1e54be83072637df5c33ab48d45832bd999f0dc6239f645cL28-R28) [[2]](diffhunk://#diff-457829b63d3eb12ed08aa6af679d570c7cac3363907b2a6b9a56c87fa915bc9aL35-R35) [[3]](diffhunk://#diff-a80910703bf075cee52fa3ab1d42200b332379c985c0ddc61a773358c7a83089L160-R160) and others)

### Example Update:

* [`examples/example.go`](diffhunk://#diff-45722259551e45f14e69b61b473a3ec59b9561abcfe74207a281203818e8e160L28-R28): Updated the example code to use `NewNode` instead of `NewP2PNode`, ensuring the example reflects the latest API changes.

This refactor ensures consistency in the naming convention and improves the clarity of the API for developers.## What Changed
- 

## Why It Was Necessary
- 

## Testing Performed
- 

## Impact / Risk
-

## Notifications
- @username
