### PR TITLE
Move to using a logger interface

### DIFF
--- a/node.go
+++ b/node.go
@@ -45,7 +45,7 @@ import (
 //   - config: P2P-specific configuration parameters defining network behavior
 //
 // Returns a fully initialized P2P node ready for starting, or an error if initialization fails.
-func NewNode(ctx context.Context, logger *logrus.Logger, config Config) (*Node, error) {
+func NewNode(ctx context.Context, logger logrus.FieldLogger, config Config) (*Node, error) {
 	logger.Infof("[Node] Creating node")
 
 	var (
@@ -202,7 +202,7 @@ func NewNode(ctx context.Context, logger *logrus.Logger, config Config) (*Node, 
 // Returns:
 //   - A configured libp2p host ready for private network operation
 //   - Error if the shared key is invalid or host creation fails
-func setUpPrivateNetwork(logger *logrus.Logger, config Config, pk *crypto.PrivKey) (host.Host, error) {
+func setUpPrivateNetwork(logger logrus.FieldLogger, config Config, pk *crypto.PrivKey) (host.Host, error) {
 	var h host.Host
 
 	s := ""
@@ -246,7 +246,7 @@ func setUpPrivateNetwork(logger *logrus.Logger, config Config, pk *crypto.PrivKe
 
 // buildAdvertiseMultiAddrs constructs multiaddrs from host strings with optional ports.
 // Logs warnings via fmt.Printf for invalid addresses.
-func buildAdvertiseMultiAddrs(log *logrus.Logger, addrs []string, defaultPort int) []multiaddr.Multiaddr {
+func buildAdvertiseMultiAddrs(log logrus.FieldLogger, addrs []string, defaultPort int) []multiaddr.Multiaddr {
 	result := make([]multiaddr.Multiaddr, 0, len(addrs))
 
 	for _, addr := range addrs {

--- a/types.go
+++ b/types.go
@@ -33,7 +33,7 @@ type Node struct {
 	host              host.Host                      // libp2p host for network communication
 	pubSub            *pubsub.PubSub                 // Publish-subscribe system for topic-based messaging
 	topics            map[string]*pubsub.Topic       // Map of topic names to topic objects
-	logger            *logrus.Logger                 // Logger for P2P operations
+	logger            logrus.FieldLogger             // Logger for P2P operations
 	bitcoinProtocolID string                         // Protocol identifier for Bitcoin-specific streams
 	handlerByTopic    map[string]Handler             // Map of topic handlers for message processing
 	startTime         time.Time                      // Time when the node was started


### PR DESCRIPTION
This pull request refactors the logging system in the `node.go` and `types.go` files by replacing the use of `*logrus.Logger` with the more generic `logrus.FieldLogger` interface. This change improves flexibility by allowing different logging implementations while maintaining compatibility with `logrus`.

### Refactoring logging system:

* **`NewNode` function**: Updated the `logger` parameter type from `*logrus.Logger` to `logrus.FieldLogger` to allow more versatile logging implementations. (`node.go`, [node.goL48-R48](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4L48-R48))
* **`setUpPrivateNetwork` function**: Changed the `logger` parameter type from `*logrus.Logger` to `logrus.FieldLogger` for consistency with the new logging approach. (`node.go`, [node.goL205-R205](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4L205-R205))
* **`buildAdvertiseMultiAddrs` function**: Modified the `log` parameter type from `*logrus.Logger` to `logrus.FieldLogger` to align with the updated logging standard. (`node.go`, [node.goL249-R249](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4L249-R249))
* **`Node` struct**: Replaced the `logger` field type from `*logrus.Logger` to `logrus.FieldLogger` to support the more generic logging interface. (`types.go`, [types.goL36-R36](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059L36-R36))
