### PR TITLE
Set starting height for peer and support listen only mode

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -61,6 +61,12 @@ type NodeI interface {
 	// UpdatePeerHeight updates the height of a peer, which is used to track the blockchain state of that peer.
 	UpdatePeerHeight(peerID peer.ID, height int32)
 
+	// GetPeerStartingHeight retrieves the initial height of a peer at the time of connection.
+	GetPeerStartingHeight(peerID peer.ID) (int32, bool)
+
+	// SetPeerStartingHeight sets the initial height of a peer at the time of connection.
+	SetPeerStartingHeight(peerID peer.ID, height int32)
+
 	// Stats methods
 
 	// LastSend returns the timestamp of the last message sent by the node.

--- a/types.go
+++ b/types.go
@@ -14,6 +14,11 @@ import (
 const (
 	errorCreatingDhtMessage = "[Node] error creating DHT: %w"
 	multiAddrIPTemplate     = "/ip4/%s/tcp/%d"
+
+	// ListenModeFull defines the node should operate in full mode
+	ListenModeFull = "full"
+	// ListenModeListenOnly defines the node should operate in listen-only mode
+	ListenModeListenOnly = "listen_only"
 )
 
 // Node implements the NodeI interface and provides the core functionality
@@ -40,12 +45,13 @@ type Node struct {
 	callbackMutex     sync.RWMutex                   // Mutex for thread-safe callback access
 
 	// IMPORTANT: The following variables must only be used atomically.
-	bytesReceived uint64   // Counter for bytes received over the network
-	bytesSent     uint64   // Counter for bytes sent over the network
-	lastRecv      int64    // Timestamp of last message received
-	lastSend      int64    // Timestamp of last message sent
-	peerHeights   sync.Map // Thread-safe map tracking peer blockchain heights
-	peerConnTimes sync.Map // Thread-safe map tracking peer connection times (peer.ID -> time.Time)
+	bytesReceived       uint64   // Counter for bytes received over the network
+	bytesSent           uint64   // Counter for bytes sent over the network
+	lastRecv            int64    // Timestamp of last message received
+	lastSend            int64    // Timestamp of last message sent
+	peerHeights         sync.Map // Thread-safe map tracking peer blockchain heights
+	peerStartingHeights sync.Map // Thread-safe map for initial peer heights at connection time
+	peerConnTimes       sync.Map // Thread-safe map tracking peer connection times (peer.ID -> time.Time)
 }
 
 // Handler defines the function signature for topic message handlers.
@@ -76,6 +82,7 @@ type Config struct {
 	OptimiseRetries    bool     // Whether to optimize connection retry behavior
 	Advertise          bool     // Whether to advertise this node's presence on the network
 	StaticPeers        []string // List of peer addresses to always attempt to connect to
+	ListenMode         string   // Mode of operation: "full" for active participation, "listen_only" for passive listening
 }
 
 // Logger defines the interface for logging within the P2P node.


### PR DESCRIPTION
This pull request introduces enhancements to the peer management system and logging functionality in the P2P node, as well as a new "listen-only" operational mode. Key changes include adding functionality to track peers' starting heights, improving logging for topic handling and message publishing, and implementing conditional behavior for the "listen-only" mode.

### Peer Management Enhancements:
* Added `StartingHeight` to the `PeerInfo` struct to track the initial blockchain height of a peer when first connected. (`node.go`, [node.goR1087](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R1087))
* Introduced methods `SetPeerStartingHeight` and `GetPeerStartingHeight` in the `NodeI` interface and implemented them to manage peers' starting heights. (`interface.go`, [[1]](diffhunk://#diff-189ad68e1729b49c973b8a4baa0ac4a7058d274d5b52abe852ac21a28accf8cfR64-R69); `node.go`, [[2]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R1189-R1213)
* Updated `ConnectedPeers` and `CurrentlyConnectedPeers` methods to include `StartingHeight` in their output. (`node.go`, [[1]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R1106-R1110) [[2]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R1121) [[3]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R1146-R1150) [[4]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R1161)

### Logging Improvements:
* Added an informational log when successfully subscribing to a topic in `SetTopicHandler`. (`node.go`, [node.goR473](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R473))
* Enhanced logging in `SetTopicHandler` to differentiate between handshake messages (logged at `info` level) and other messages (logged at `debug` level). (`node.go`, [node.goR493-R498](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R493-R498))

### Listen-Only Mode:
* Introduced a new configuration option, `ListenMode`, with values `"full"` and `"listen_only"`. (`types.go`, [[1]](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059R17-R21) [[2]](diffhunk://#diff-b990161986c40e0867e71c60779bc98a8730a9eb0ca5866ae8189e126863c059R85)
* Modified `Publish` and `SendToPeer` methods to prevent outbound messages in "listen-only" mode, except for essential handshake messages. (`node.go`, [[1]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R519-R527) [[2]](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R553-R560)
