### PR TITLE
Add connect to peer support

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -49,6 +49,9 @@ type NodeI interface {
 	// CurrentlyConnectedPeers returns a list of currently connected peers with their information.
 	CurrentlyConnectedPeers() []PeerInfo
 
+	// ConnectToPeer connects to a peer identified by its ID, establishing a P2P connection.
+	ConnectToPeer(ctx context.Context, peer string) error
+
 	// DisconnectPeer disconnects a peer from the P2P network, removing it from the list of connected peers.
 	DisconnectPeer(ctx context.Context, peerID peer.ID) error
 

--- a/mocks/mock_p2pnode.go
+++ b/mocks/mock_p2pnode.go
@@ -81,6 +81,12 @@ func (m *MockP2PNode) CurrentlyConnectedPeers() []PeerInfo {
 	return nil
 }
 
+// ConnectToPeer mocks the ConnectToPeer method
+func (m *MockP2PNode) ConnectToPeer(ctx context.Context, peer string) error {
+	args := m.Called(ctx, peer)
+	return args.Error(0)
+}
+
 // DisconnectPeer mocks the DisconnectPeer method
 func (m *MockP2PNode) DisconnectPeer(ctx context.Context, peerID peer.ID) error {
 	args := m.Called(ctx, peerID)

--- a/node_test.go
+++ b/node_test.go
@@ -493,7 +493,7 @@ func TestP2PNode_ConnectToPeer(t *testing.T) {
 
 	t.Run("successful connection", func(t *testing.T) {
 		err := node1.ConnectToPeer(ctx, node2Addr)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify connection
 		peers := node1.host.Network().Peers()
@@ -631,7 +631,7 @@ func TestP2PNode_ConnectToPeer(t *testing.T) {
 			time.Sleep(100 * time.Millisecond) // Give time for disconnection
 
 			err := node1.ConnectToPeer(ctx, format)
-			assert.NoError(t, err, "Failed with format: %s", format)
+			require.NoError(t, err, "Failed with format: %s", format)
 
 			// Verify connection
 			peers := node1.host.Network().Peers()


### PR DESCRIPTION
This pull request introduces a new `ConnectToPeer` feature to the P2P networking module, enabling nodes to establish connections with specific peers. The changes include updates to the interface, implementation, mock, and extensive test coverage for various scenarios. Additionally, a minor logging level adjustment was made for error handling during peer discovery.

### New `ConnectToPeer` Feature:

* **Interface Update**: Added the `ConnectToPeer` method to the `NodeI` interface, allowing nodes to connect to peers by their ID. (`interface.go`, [interface.goR52-R54](diffhunk://#diff-189ad68e1729b49c973b8a4baa0ac4a7058d274d5b52abe852ac21a28accf8cfR52-R54))
* **Implementation**: Implemented the `ConnectToPeer` method in the `Node` struct to handle multiaddr parsing, peer info extraction, and connection establishment. (`node.go`, [node.goR1331-R1353](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4R1331-R1353))
* **Mock Update**: Added a mock implementation of the `ConnectToPeer` method in `MockP2PNode` for testing purposes. (`mocks/mock_p2pnode.go`, [mocks/mock_p2pnode.goR84-R89](diffhunk://#diff-eefeb7fe9fe1e85afc51e56a994e7a88ef43e420bb7602b8e5d34716c225922fR84-R89))

### Test Enhancements:

* **New Test Cases**: Added comprehensive tests for `ConnectToPeer` in `node_test.go`, covering successful connections, invalid addresses, reconnections, context cancellation, and various multiaddr formats. (`node_test.go`, [node_test.goR460-R641](diffhunk://#diff-a80910703bf075cee52fa3ab1d42200b332379c985c0ddc61a773358c7a83089R460-R641))
* **Imports Update**: Added necessary imports for testing and string manipulation. (`node_test.go`, [node_test.goR5-R6](diffhunk://#diff-a80910703bf075cee52fa3ab1d42200b332379c985c0ddc61a773358c7a83089R5-R6))

### Logging Adjustment:

* **Peer Discovery**: Changed the logging level for peer discovery errors from `Error` to `Warn` to reduce noise in logs for non-critical issues. (`node.go`, [node.goL383-R383](diffhunk://#diff-c83030810249b817b40da2c3ba5486a5511318dac31027a4e52d9c903e8b4cf4L383-R383))
