### PR TITLE
Add new message types for block header and handshake

### DIFF
--- a/message_types.go
+++ b/message_types.go
@@ -43,6 +43,7 @@ type BlockMessage struct {
 	Height     uint32 // Position of the block in the blockchain
 	DataHubURL string // URL where the complete block data can be retrieved
 	PeerID     string // Identifier of the peer announcing the block
+	Header     string // Hexadecimal representation of the block header
 }
 
 // SubtreeMessage announces the availability of a subtree (transaction batch) to the network.
@@ -99,11 +100,12 @@ const (
 //
 // Fields are JSON-tagged to support serialization for network transmission.
 type HandshakeMessage struct {
-	Type       MessageType `json:"type"`
-	PeerID     string      `json:"peerID"`
-	BestHeight uint32      `json:"bestHeight"`
-	BestHash   string      `json:"bestHash"`
-	DataHubURL string      `json:"dataHubURL"`
-	UserAgent  string      `json:"userAgent"`
-	Services   uint64      `json:"services"`
+	Type        MessageType `json:"type"`
+	PeerID      string      `json:"peerID"`
+	BestHeight  uint32      `json:"bestHeight"`
+	BestHash    string      `json:"bestHash"`
+	DataHubURL  string      `json:"dataHubURL"`
+	UserAgent   string      `json:"userAgent"`
+	Services    uint64      `json:"services"`
+	TopicPrefix string      `json:"topicPrefix"` // Chain identifier to validate compatibility
 }


### PR DESCRIPTION
This pull request updates the `message_types.go` file to enhance the structure of blockchain-related messages by adding new fields to existing message types. The changes improve the ability to convey additional metadata and ensure compatibility during network communication.

### Enhancements to message structures:

* `BlockMessage` struct: Added a new `Header` field to store the hexadecimal representation of the block header, providing more detailed information about the block.
* `HandshakeMessage` struct: Added a new `TopicPrefix` field to include a chain identifier, enabling validation of compatibility between peers during the handshake process.