### PR TITLE
Add coinbase transaction to block message type

### DIFF
--- a/message_types.go
+++ b/message_types.go
@@ -44,7 +44,7 @@ type BlockMessage struct {
 	DataHubURL string // URL where the complete block data can be retrieved
 	PeerID     string // Identifier of the peer announcing the block
 	Header     string // Hexadecimal representation of the block header
-	Coinbase string // Hexadecimal representation of the coinbase transaction
+	Coinbase   string // Hexadecimal representation of the coinbase transaction
 }
 
 // SubtreeMessage announces the availability of a subtree (transaction batch) to the network.


### PR DESCRIPTION
This pull request makes a small change to the `BlockMessage` struct in `message_types.go` by adding a new field for the coinbase transaction. This addition will allow the coinbase transaction to be included in block announcements.