### PR TITLE
feat: add ClientName field to BlockMessage and SubtreeMessage

### DIFF
--- a/message_types.go
+++ b/message_types.go
@@ -45,6 +45,7 @@ type BlockMessage struct {
 	PeerID     string // Identifier of the peer announcing the block
 	Header     string // Hexadecimal representation of the block header
 	Coinbase   string // Hexadecimal representation of the coinbase transaction
+	ClientName string // Name of the client software announcing the block
 }
 
 // SubtreeMessage announces the availability of a subtree (transaction batch) to the network.
@@ -61,6 +62,7 @@ type SubtreeMessage struct {
 	Hash       string // Unique hash identifier of the subtree
 	DataHubURL string // URL where the subtree data can be retrieved
 	PeerID     string // Identifier of the peer announcing the subtree
+	ClientName string // Name of the client software announcing the subtree
 }
 
 // RejectedTxMessage notifies peers about a rejected transaction.


### PR DESCRIPTION
## Summary
- Add `ClientName` field to `BlockMessage` struct to track the client software announcing blocks
- Add `ClientName` field to `SubtreeMessage` struct to track the client software announcing subtrees

This enhancement allows the system to identify which client software is announcing blocks and subtrees, providing better visibility into the network topology and client distribution.

## Changes
- `message_types.go:48`: Added `ClientName string` field to `BlockMessage`
- `message_types.go:65`: Added `ClientName string` field to `SubtreeMessage`

## Test plan
- [ ] Verify BlockMessage serialization/deserialization with new field
- [ ] Verify SubtreeMessage serialization/deserialization with new field
- [ ] Confirm backward compatibility with clients not sending ClientName
- [ ] Validate that ClientName is properly populated when messages are created